### PR TITLE
Fixed logic for click event

### DIFF
--- a/lib/SimpleListView.coffee
+++ b/lib/SimpleListView.coffee
@@ -20,7 +20,13 @@ class SimpleSelectListView extends View
       e.preventDefault()
       e.stopPropagation()
 
-      @selectItemView $(e.target).closest("li")
+      view = $(e.target).closest("li")
+      item = @findItemFromView view
+      if item
+        itemIndex = @items.indexOf item
+        if itemIndex >= 0
+          @curIndex = itemIndex
+          @selectItemView view
 
     @list.on "mouseup", "li", (e) =>
       e.preventDefault()
@@ -57,6 +63,16 @@ class SimpleSelectListView extends View
   setItems: (items=[]) ->
     @items = items
     @populateList()
+
+  # Private: Searches the items array for the item corresponding to the view
+  #
+  # view - the {jQuery} view to be selected
+  findItemFromView: (view) ->
+    return unless view.length
+    viewText = view.text().trim()
+    items = @items.filter (item) ->
+      item.title == viewText
+    return items[0]
 
   # Private: Unselects all views, selects the given view
   #


### PR DESCRIPTION
Hi, I have made a simple fix for when you click on an item on the list.

In the current package, whenever you Ctrl-Tab to open the file list and click on an item down on the list, the editor always opens the first item in the list, instead of the one that you clicked. This is happening because the click handler only sets the DOM element as highlighted, but without updating the curIndex.

My fix is to add a simple function that searches for the item that corresponds to the clicked element, so that the click event handler can call this function and set the curIndex variable accordingly.
